### PR TITLE
Fix respond_to? in Redis::Retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 pkg
+.bundle
+.bin

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,8 @@
+source :rubygems
+
+gemspec
+
+gem 'jeweler'
+gem 'rake'
+gem 'redis'
+gem 'mocha'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,33 @@
+PATH
+  remote: .
+  specs:
+    redis-retry (0.1.0)
+      redis
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    git (1.2.5)
+    jeweler (1.8.4)
+      bundler (~> 1.0)
+      git (>= 1.2.5)
+      rake
+      rdoc
+    json (1.7.5)
+    metaclass (0.0.1)
+    mocha (0.12.5)
+      metaclass (~> 0.0.1)
+    rake (0.9.2.2)
+    rdoc (3.12)
+      json (~> 1.4)
+    redis (3.0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jeweler
+  mocha
+  rake
+  redis
+  redis-retry!

--- a/lib/redis/retry.rb
+++ b/lib/redis/retry.rb
@@ -36,5 +36,11 @@ class Redis
       # Ran out of retries
       raise Errno::ECONNREFUSED
     end
+
+    def respond_to?(method)
+      return true if super(method)
+
+      @redis.respond_to?(method)
+    end
   end
 end

--- a/lib/redis/retry.rb
+++ b/lib/redis/retry.rb
@@ -23,18 +23,20 @@ class Redis
 
     def method_missing(command, *args, &block)
       try = 1
+      exception = nil
       while try <= @tries
         begin
           # Dispatch the command to Redis
           return @redis.send(command, *args, &block)
-        rescue Errno::ECONNREFUSED
+        rescue Errno::ECONNREFUSED, Errno::ECONNRESET => e
           try += 1
+          exception = e
           sleep @wait
         end
       end
 
       # Ran out of retries
-      raise Errno::ECONNREFUSED
+      raise exception
     end
 
     def respond_to?(method)

--- a/test/test_redis_retry.rb
+++ b/test/test_redis_retry.rb
@@ -21,6 +21,11 @@ class TestRedisRetry < Test::Unit::TestCase
     assert @redis['foo']
   end
 
+  def test_should_retry_after_receiving_connection_reset
+    @r.stubs(:send).raises(Errno::ECONNRESET).then.returns(true)
+    assert @redis['foo']
+  end
+
   def test_should_retry_as_many_times_as_possible
     send = sequence('send')
     @r.stubs(:send).raises(Errno::ECONNREFUSED).times(9).in_sequence(send)

--- a/test/test_redis_retry.rb
+++ b/test/test_redis_retry.rb
@@ -44,4 +44,10 @@ class TestRedisRetry < Test::Unit::TestCase
     assert @redis['foo']
     assert @redis['bar']
   end
+
+  def test_respond_to
+    assert @redis.respond_to?(:tries)
+    assert @redis.respond_to?(:get)
+    assert !@redis.respond_to?(:method_that_does_not_exist)
+  end
 end


### PR DESCRIPTION
Currently, a Redis::Retry instance does not respond_to? methods delegated to the wrapped Redis instance.  Any method that's delegated via method_missing should also be wired up to respond_to?.
- Fix respond_to?
- Add bundler support
